### PR TITLE
Add wrap guide to atom theme

### DIFF
--- a/index.less
+++ b/index.less
@@ -42,6 +42,10 @@
   padding-left: calc(0.5em - 5px);
 }
 
+.editor .wrap-guide {
+  background-color: #303341;
+}
+
 .comment {
   color: #6272a4;
 }


### PR DESCRIPTION
![screen_shot_2014-03-04_at_15_09_24](https://f.cloud.github.com/assets/431892/2324423/fdd8bb30-a3c8-11e3-9ae6-27c44a2779a0.png)

The wrap guide is shown when the [wrap guide](https://github.com/atom/wrap-guide/) package is enabled.