### PR TITLE
Move xml declaration to top of file.

### DIFF
--- a/Dracula.tmTheme
+++ b/Dracula.tmTheme
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Dracula Theme v0.7.4
 #
 # https://github.com/zenorocha/dracula-theme
@@ -10,7 +11,6 @@
 # @author Zeno Rocha <hi@zenorocha.com>
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>


### PR DESCRIPTION
In it's current state when other plugins try to open the Dracula.tmTheme, it return a `xml.etree.ElementTree.ParseError: XML or text declaration not at start of entity: line 13, column 0` when trying to create a plist from ElementTree.XML()

Closes SublimeLinter/SublimeLinter3#192