### PR TITLE
Add CriticMarkup support

### DIFF
--- a/index.less
+++ b/index.less
@@ -268,3 +268,23 @@
 .code.gfm .link {
     color: #8be9fd;
 }
+
+.critic.gfm.addition {
+  color: #50fa7b;
+}
+
+.critic.gfm.deletion {
+  color: #ff5555;
+}
+
+.critic.gfm.substitution {
+  color:  #ffb86c;
+}
+
+.critic.gfm.highlight {
+  color: #ff79c6;
+}
+
+.critic.gfm.comment {
+  color: #6272a4;
+}


### PR DESCRIPTION
https://github.com/atom/atom/releases/tag/v0.197.0

> CriticMarkup is now colorized in Markdown files