### PR TITLE
Fixed a bug on Markdown Preview

### DIFF
--- a/index.less
+++ b/index.less
@@ -51,6 +51,12 @@
   padding-left: calc(0.5em - 5px);
 }
 
+.markdown-preview > atom-text-editor.editor {
+    background: #ffffff;
+    border: 1px solid #e6e6e6;
+    color: #aaaaaa;
+}
+
 .wrap-guide {
   background-color: #6272a4;
 }


### PR DESCRIPTION
I fixed the bug which I reported on #94.
This bug happens on version 0.204.0 of Atom on both Mac 10.9.5 and 10.10.3. And it doesn't happen  version 0.165.0 of Atom (on Mac 10.9.5).

On version 0.165.0, following css was used, so I added the same css.

{
    background: #ffffff;
    border: 1px solid #e6e6e6;
    color: #aaaaaa;
}

