### PR TITLE
Use actual filename casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Plugin 'zenorocha/dracula-theme', {'rtp': 'vim/'}
 If you aren't so clever just move the `vim/dracula.vim` file into `~/.vim/colors` and add the following lines into your vimrc file:
 
     syntax on
-    color Dracula
+    color dracula
 
 
 ## Xcode


### PR DESCRIPTION
On OSX, by default, the filesystem is case-preserving, so locating
Dracula works fine. However, many linux filesystems are case-sensitive
so `colorscheme Dracula` causes the colorscheme to not be found.