### PR TITLE
a bug of markdown preview when I write markdown code blocks

### DIFF
--- a/index.less
+++ b/index.less
@@ -51,6 +51,11 @@
   padding-left: calc(0.5em - 5px);
 }
 
+.markdown-preview > atom-text-editor.editor {
+    background: #282A36;
+    border: 1px solid #282A36;
+}
+
 .wrap-guide {
   background-color: #6272a4;
 }


### PR DESCRIPTION
I find a bug of markdown preview when I write markdown code blocks.

Here is the bug before I fixed:

![markdown preview's bug](https://github.com/iamtomatokiller/markdown-learn/blob/master/bug.png)

Then I fixed it:

![fixed](https://github.com/iamtomatokiller/markdown-learn/blob/master/fixed-bug.png)
