### PR TITLE
Fix case of g:colors_name

### DIFF
--- a/vim/colors/dracula.vim
+++ b/vim/colors/dracula.vim
@@ -17,7 +17,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Dracula"
+let g:colors_name = "dracula"
 
 hi Cursor ctermfg=17 ctermbg=231 cterm=NONE guifg=#282a36 guibg=#f8f8f0 gui=NONE
 hi Visual ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#44475a gui=NONE


### PR DESCRIPTION
I always got an error when starting vim that there is no colorscheme named `Dracula`, because it has to be set as `colorscheme dracula` but `g:colors_name` was used in `syntax/synload.vim` on line 19 and was set to `Dracula`, so I changed that and now I don't get this error anymore, which is nice...