### PR TITLE
QtCreator syntax highlight

### DIFF
--- a/qtcreator/dracula.xml
+++ b/qtcreator/dracula.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<style-scheme version="1.0" name="Dracula">
+  <style name="Text" foreground="#f8f8f2" background="#282a36"/>
+  <style name="Link" foreground="#0055ff"/>
+  <style name="Selection" foreground="#000000" background="#aaaaaa"/>
+  <style name="LineNumber" foreground="#888888" background="#232323"/>
+  <style name="SearchResult" background="#555500"/>
+  <style name="SearchScope" background="#222200"/>
+  <style name="Parentheses" foreground="#ff5555" background="#333333"/>
+  <style name="ParenthesesMismatch" foreground="#000000" background="#ff00ff"/>
+  <style name="CurrentLine" background="#232323"/>
+  <style name="CurrentLineNumber" foreground="#aaaaaa" bold="true"/>
+  <style name="Occurrences" background="#363636"/>
+  <style name="Occurrences.Unused" foreground="#808000"/>
+  <style name="Occurrences.Rename" foreground="#ffaaaa" background="#553636"/>
+  <style name="Number" foreground="#ff55ff"/>
+  <style name="String" foreground="#f1fa8c"/>
+  <style name="Type" foreground="#50fa7b"/>
+  <style name="Local"/>
+  <style name="Field"/>
+  <style name="Static" foreground="#55ff55" italic="true"/>
+  <style name="VirtualMethod" italic="true"/>
+  <style name="Function" foreground="#8be9fd"/>
+  <style name="Keyword" foreground="#fe79c5"/>
+  <style name="PrimitiveType" foreground="#8be9fd" italic="true"/>
+  <style name="Operator" foreground="#aaaaaa"/>
+  <style name="Preprocessor" foreground="#ff79c6"/>
+  <style name="Label" foreground="#ffff55"/>
+  <style name="Comment" foreground="#6272a4"/>
+  <style name="Doxygen.Comment" foreground="#6272a4"/>
+  <style name="Doxygen.Tag" foreground="#00a0a0"/>
+  <style name="VisualWhitespace" foreground="#c0c0c0"/>
+  <style name="QmlLocalId" italic="true"/>
+  <style name="QmlExternalId" foreground="#aaaaff" italic="true"/>
+  <style name="QmlTypeId" foreground="#55ff55"/>
+  <style name="QmlRootObjectProperty" italic="true"/>
+  <style name="QmlScopeObjectProperty" italic="true"/>
+  <style name="QmlExternalObjectProperty" foreground="#aaaaff" italic="true"/>
+  <style name="JsScopeVar" foreground="#8888ff" italic="true"/>
+  <style name="JsImportVar" foreground="#8888ff" italic="true"/>
+  <style name="JsGlobalVar" foreground="#8888ff" italic="true"/>
+  <style name="QmlStateName" italic="true"/>
+  <style name="Binding" foreground="#ff5555"/>
+  <style name="DisabledCode" foreground="#424242" background="#272822"/>
+  <style name="AddedLine" foreground="#55ffff"/>
+  <style name="RemovedLine" foreground="#ff5555"/>
+  <style name="DiffFile" foreground="#55ff55"/>
+  <style name="DiffLocation" foreground="#ffff55"/>
+  <style name="DiffFileLine" foreground="#000000" background="#d7d700"/>
+  <style name="DiffContextLine" foreground="#000000" background="#8aaab6"/>
+  <style name="DiffSourceLine" background="#8c2d2d"/>
+  <style name="DiffSourceChar" foreground="#000000" background="#c34141"/>
+  <style name="DiffDestLine" background="#2d8c2d"/>
+  <style name="DiffDestChar" foreground="#000000" background="#41c341"/>
+  <style name="LogChangeLine" foreground="#c00000"/>
+</style-scheme>


### PR DESCRIPTION
Syntax style applied for QtCreator.
Just copy dracula.xml to:

* Linux:  `~/.config/QtProject/qtcreator/styles`
* Windows (7 and up): `Users\<user name>\AppData\Roaming\QtProject\qtcreator\styles`

Start (or restart) QtCreator and select the Dracula color scheme in the options dialog.