### PR TITLE
Make codeblock text visible in markdown preview

### DIFF
--- a/index.less
+++ b/index.less
@@ -60,6 +60,10 @@
   border: 1px solid #282A36;
 }
 
+.markdown-preview .editor {
+  color: #000000;
+}
+
 .wrap-guide {
   background-color: #6272a4;
 }


### PR DESCRIPTION
# Before:
![screen shot 2016-04-22 at 9 53 50 am](https://cloud.githubusercontent.com/assets/6378836/14748921/5011a510-0871-11e6-952b-0f37c1513b87.png)

# After:
![screen shot 2016-04-22 at 9 50 38 am](https://cloud.githubusercontent.com/assets/6378836/14748925/5868c464-0871-11e6-919c-da8754ffba70.png)


Signed-off-by: Travis Yoder <trayoda@gmail.com>