### PR TITLE
Add colors trying to match the best Atom highlight and added several …

### DIFF
--- a/jetbrains/Dracula.icls
+++ b/jetbrains/Dracula.icls
@@ -1,278 +1,120 @@
-<scheme name="Dracula" parent_scheme="Default" version="1">
-  <option name="LINE_SPACING" value="1.0" />
-  <option name="EDITOR_FONT_SIZE" value="12" />
-  <option name="EDITOR_FONT_NAME" value="Menlo" />
+<scheme name="Dracula" version="140" parent_scheme="Darcula">
+  <option name="LINE_SPACING" value="1.2" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="CONSOLE_FONT_NAME" value="Source Code Pro" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
   <colors>
-    <option name="CONSOLE_BACKGROUND_KEY" value="282a36" />
-    <option name="INDENT_GUIDE" value="3B3A32" />
-    <option name="SELECTION_BACKGROUND" value="44475a" />
-    <option name="CARET_ROW_COLOR" value="1f2235" />
-    <option name="WHITESPACES" value="3B3A32" />
-    <option name="CARET_COLOR" value="f8f8f0" />
-    <option name="LINE_NUMBERS_COLOR" value="f8f8f2" />
-    <option name="SELECTED_INDENT_GUIDE" value="3B3A32" />
+    <option name="CARET_COLOR" value="cccccc" />
+    <option name="CARET_ROW_COLOR" value="44475a" />
     <option name="GUTTER_BACKGROUND" value="282a36" />
+    <option name="LINE_NUMBERS_COLOR" value="666879" />
+    <option name="SELECTION_BACKGROUND" value="666b87" />
+    <option name="SELECTION_FOREGROUND" value="44475a" />
   </colors>
   <attributes>
-    <option name="BAD_CHARACTER">
+    <option name="ABSTRACT_CLASS_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option name="BREAKPOINT_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="743d3d" />
-      </value>
-    </option>
-    <option name="BUILDOUT.KEY">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="BUILDOUT.KEY_VALUE_SEPARATOR">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="BUILDOUT.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="BUILDOUT.SECTION_NAME">
+    <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
-    <option name="BUILDOUT.VALUE">
+    <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="CLASS_NAME_ATTRIBUTES" />
-    <option name="CLASS_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
+        <option name="FOREGROUND" value="8be9fd" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="50fa7b" />
       </value>
     </option>
-    <option name="COFFEESCRIPT.BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BOOLEAN">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_BRACES" name="COFFEESCRIPT.BRACE" />
-    <option baseAttributes="DEFAULT_BRACKETS" name="COFFEESCRIPT.BRACKET" />
-    <option name="COFFEESCRIPT.CLASS_NAME">
+    <option name="ANONYMOUS_CLASS_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="COFFEESCRIPT.COLON">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_COMMA" name="COFFEESCRIPT.COMMA" />
-    <option baseAttributes="DEFAULT_DOT" name="COFFEESCRIPT.DOT" />
-    <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.EXISTENTIAL">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK" />
-    <option name="COFFEESCRIPT.FUNCTION">
+    <option name="BASH.EXTERNAL_COMMAND">
       <value>
         <option name="FOREGROUND" value="8be9fd" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="COFFEESCRIPT.FUNCTION_BINDING">
+    <option name="BASH.INTERNAL_COMMAND">
       <value>
         <option name="FOREGROUND" value="8be9fd" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="COFFEESCRIPT.FUNCTION_NAME">
+    <option name="CLASS_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option baseAttributes="COFFEESCRIPT.IDENTIFIER" name="COFFEESCRIPT.GLOBAL_VARIABLE" />
-    <option name="COFFEESCRIPT.HEREDOC_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREDOC_ID">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREGEX_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREGEX_ID">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.IDENTIFIER">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_STRING" name="COFFEESCRIPT.JAVASCRIPT_CONTENT" />
-    <option name="COFFEESCRIPT.JAVASCRIPT_ID">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.LOCAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="COFFEESCRIPT.OBJECT_KEY" />
-    <option name="COFFEESCRIPT.OPERATIONS">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_PARENTHS" name="COFFEESCRIPT.PARENTHESIS" />
-    <option name="COFFEESCRIPT.PROTOTYPE">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_DOT" name="COFFEESCRIPT.RANGE" />
-    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_SEMICOLON" name="COFFEESCRIPT.SEMICOLON" />
-    <option baseAttributes="DEFAULT_DOT" name="COFFEESCRIPT.SPLAT" />
-    <option name="COFFEESCRIPT.STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.STRING_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_KEYWORD" name="COFFEESCRIPT.THIS" />
-    <option name="CONDITIONALLY_NOT_COMPILED">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLUE_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-      </value>
-    </option>
-    <option name="CONSOLE_CYAN_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="06b8b8" />
       </value>
     </option>
     <option name="CONSOLE_ERROR_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ffb3b3" />
+        <option name="FOREGROUND" value="ff5555" />
       </value>
     </option>
-    <option name="CONSOLE_GRAY_OUTPUT">
+    <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="a7a7a7" />
+        <option name="FOREGROUND" value="51ff7c" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="68e868" />
+        <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
     <option name="CONSOLE_MAGENTA_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff2eff" />
+        <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
-    <option name="CONSOLE_NORMAL_OUTPUT">
+    <option name="CONSOLE_RANGE_TO_EXECUTE">
       <value>
-        <option name="FOREGROUND" value="ffffff" />
+        <option name="EFFECT_COLOR" value="bd93f9" />
       </value>
     </option>
     <option name="CONSOLE_RED_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="ff6767" />
+        <option name="FOREGROUND" value="ff5555" />
       </value>
     </option>
-    <option name="CONSOLE_SYSTEM_OUTPUT">
+    <option name="CONSOLE_SELECTED_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="e4e4ff" />
+        <option name="BACKGROUND" value="242632" />
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
       <value>
-        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FOREGROUND" value="50fa7b" />
         <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CONSOLE_WHITE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="CONSOLE_YELLOW_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="754200" />
+        <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
-    <option name="CSS.COMMENT">
+    <option name="CONSTRUCTOR_CALL_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="CONSTRUCTOR_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="50fa7b" />
+      </value>
+    </option>
+    <option name="CSS.COLOR">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
     <option name="CSS.FUNCTION">
@@ -285,21 +127,22 @@
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option name="CSS.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
+    <option name="CSS.IMPORTANT" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="CSS.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
     <option name="CSS.PROPERTY_NAME">
       <value>
-        <option name="FOREGROUND" value="66d9ef" />
+        <option name="FOREGROUND" value="8be9fd" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
-        <option name="FOREGROUND" value="68e868" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="CSS.PSEUDO">
+      <value>
+        <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
     <option name="CSS.TAG_NAME">
@@ -310,98 +153,6 @@
     <option name="CSS.URL">
       <value>
         <option name="FOREGROUND" value="ffb86c" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="e3e3ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fda5ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="71d7d7" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ffc2c2" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_NUMBER_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="CUSTOM_STRING_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="Clojure Atom">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="Clojure Character">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="RUBY_IDENTIFIER" name="Clojure Keyword" />
-    <option name="Clojure Line comment">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_INSTANCE_FIELD" name="Clojure Literal" />
-    <option name="Clojure Numbers">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="Clojure Strings">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="DEFAULT_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
@@ -409,35 +160,54 @@
         <option name="FOREGROUND" value="6272a4" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="DEFAULT_BRACES" />
-    <option baseAttributes="TEXT" name="DEFAULT_BRACKETS" />
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="DEFAULT_CLASS_NAME" />
-    <option baseAttributes="TEXT" name="DEFAULT_COMMA" />
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="DEFAULT_CONSTANT" />
+    <option name="DEFAULT_CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="50fa7b" />
+      </value>
+    </option>
+    <option name="DEFAULT_CLASS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="DEFAULT_COMMA">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+      </value>
+    </option>
+    <option name="DEFAULT_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="6272a4" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
         <option name="FOREGROUND" value="6272a4" />
+        <option name="FONT_TYPE" value="3" />
+        <option name="EFFECT_COLOR" value="6272a4" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="8090c9" />
       </value>
     </option>
     <option name="DEFAULT_DOC_MARKUP">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
+        <option name="FOREGROUND" value="7282b7" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="DEFAULT_DOT" />
-    <option name="DEFAULT_ENTITY">
+    <option name="DEFAULT_DOT">
       <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="DEFAULT_FUNCTION_CALL">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
+        <option name="FOREGROUND" value="ff79c6" />
       </value>
     </option>
     <option name="DEFAULT_FUNCTION_DECLARATION">
@@ -445,38 +215,34 @@
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option name="DEFAULT_GLOBAL_VARIABLE">
+    <option name="DEFAULT_IDENTIFIER">
       <value>
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="DEFAULT_IDENTIFIER" />
-    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="DEFAULT_INSTANCE_FIELD" />
-    <option name="DEFAULT_INSTANCE_METHOD">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_CLASS_NAME" name="DEFAULT_INTERFACE_NAME" />
     <option name="DEFAULT_INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="50fa7b" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="DEFAULT_LABEL" />
     <option name="DEFAULT_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="6272a4" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="DEFAULT_LOCAL_VARIABLE" />
-    <option baseAttributes="TEXT" name="DEFAULT_METADATA" />
+    <option name="DEFAULT_METADATA">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
     <option name="DEFAULT_NUMBER">
       <value>
         <option name="FOREGROUND" value="bd93f9" />
@@ -490,25 +256,11 @@
     <option name="DEFAULT_PARAMETER">
       <value>
         <option name="FOREGROUND" value="ffb86c" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="DEFAULT_PARENTHS" />
-    <option name="DEFAULT_PREDEFINED_SYMBOL">
+    <option name="DEFAULT_SEMICOLON">
       <value>
-        <option name="FOREGROUND" value="66d9ef" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="DEFAULT_SEMICOLON" />
-    <option name="DEFAULT_STATIC_FIELD">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_STATIC_METHOD">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="DEFAULT_STRING">
@@ -516,228 +268,65 @@
         <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="DEFAULT_TAG" />
-    <option baseAttributes="TEXT" name="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
-    <option name="DEFAULT_VALID_STRING_ESCAPE">
+    <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
       <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="BACKGROUND" value="242632" />
       </value>
     </option>
-    <option name="DEPRECATED_ATTRIBUTES">
+    <option name="DEFAULT_VALID_STRING_ESCAPE">
       <value>
+        <option name="FOREGROUND" value="ffb86c" />
+      </value>
+    </option>
+    <option name="DELETED_TEXT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="933232" />
+        <option name="EFFECT_COLOR" value="c3c3c3" />
         <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
       </value>
     </option>
     <option name="DIFF_CONFLICT">
       <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
+        <option name="BACKGROUND" value="a33737" />
+        <option name="ERROR_STRIPE_COLOR" value="933232" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
+        <option name="BACKGROUND" value="4a9da9" />
+        <option name="ERROR_STRIPE_COLOR" value="305e6a" />
       </value>
     </option>
-    <option name="DJANGO_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="DJANGO_FILTER">
-      <value>
-        <option name="FOREGROUND" value="8be9fd" />
-      </value>
-    </option>
-    <option name="DJANGO_ID">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option name="DJANGO_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="DJANGO_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="DJANGO_STRING_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="DJANGO_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="e3e3ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_BRACES" name="DJANGO_TAG_START_END" />
     <option name="DUPLICATE_FROM_SERVER">
-      <value>
-        <option name="BACKGROUND" value="30322b" />
-      </value>
-    </option>
-    <option name="ENUM_CONST">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
+      <value />
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="ERROR_STRIPE_COLOR" value="9e2927" />
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
-      </value>
-    </option>
-    <option name="EXECUTIONPOINT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="000101" />
-        <option name="BACKGROUND" value="c7c7ff" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="3c3d3c" />
-        <option name="BACKGROUND" value="101010" />
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="3c3d3c" />
+        <option name="FOREGROUND" value="787e9f" />
+        <option name="BACKGROUND" value="242632" />
       </value>
     </option>
-    <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-        <option name="BACKGROUND" value="161717" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
-      </value>
-    </option>
-    <option name="First symbol in list">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="GENERIC_SERVER_ERROR_OR_WARNING">
-      <value>
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
-      </value>
-    </option>
-    <option name="GHERKIN_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="GHERKIN_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="GHERKIN_TEXT" name="GHERKIN_OUTLINE_PARAMETER_SUBSTITUTION" />
-    <option name="GHERKIN_PYSTRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="GHERKIN_REGEXP_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="GHERKIN_TEXT" name="GHERKIN_TABLE_CELL" />
-    <option baseAttributes="GHERKIN_TEXT" name="GHERKIN_TABLE_HEADER_CELL" />
-    <option name="GHERKIN_TABLE_PIPE">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="GHERKIN_TAG">
+    <option name="GO_BUILTIN_TYPE_REFERENCE">
       <value>
         <option name="FOREGROUND" value="8be9fd" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="GHERKIN_TEXT" />
-    <option name="GQL_ID">
+    <option name="GRID_ERROR_VALUE">
       <value>
-        <option name="FOREGROUND" value="bd93f9" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="ERROR_STRIPE_COLOR" value="cd4848" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="GQL_INT_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="GQL_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="GQL_STRING_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_FILTER" />
-    <option baseAttributes="HAML_TEXT" name="HAML_FILTER_CONTENT" />
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_LINE_CONTINUATION" />
-    <option baseAttributes="DEFAULT_PARENTHS" name="HAML_PARENTHS" />
-    <option baseAttributes="HAML_TEXT" name="HAML_RUBY_CODE" />
-    <option baseAttributes="HAML_TEXT" name="HAML_RUBY_START" />
-    <option name="HAML_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="HAML_STRING_INTERPOLATED">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_TAG" />
-    <option name="HAML_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="HAML_TEXT" />
-    <option baseAttributes="HAML_TEXT" name="HAML_WS_REMOVAL" />
-    <option baseAttributes="HAML_TEXT" name="HAML_XHTML" />
+    <option name="Groovy method declaration" baseAttributes="METHOD_DECLARATION_ATTRIBUTES" />
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
@@ -746,144 +335,51 @@
     <option name="HTML_ATTRIBUTE_VALUE">
       <value>
         <option name="FOREGROUND" value="f1fa8c" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="HTML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
       </value>
     </option>
     <option name="HTML_ENTITY_REFERENCE">
       <value>
         <option name="FOREGROUND" value="bd93f9" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option baseAttributes="XML_TAG" name="HTML_TAG" />
-    <option name="HTML_TAG_NAME">
+    <option name="HTML_TAG">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
-    <option name="HYPERLINK_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
-      </value>
-    </option>
+    <option name="HTML_TAG_NAME" baseAttributes="DEFAULT_KEYWORD" />
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+        <option name="BACKGROUND" value="242632" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fda5ff" />
-      </value>
-    </option>
-    <option name="INFO_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
-      </value>
-    </option>
+    <option name="IGNORE.COMMENT" baseAttributes="DEFAULT_LINE_COMMENT" />
+    <option name="IGNORE.HEADER" baseAttributes="DEFAULT_DOC_COMMENT_TAG" />
+    <option name="IGNORE.NEGATION" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="IGNORE.SECTION" baseAttributes="DEFAULT_DOC_COMMENT" />
+    <option name="IGNORE.SYNTAX" baseAttributes="DEFAULT_INSTANCE_FIELD" />
+    <option name="IGNORE.VALUE" baseAttributes="DEFAULT_STRING" />
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value>
-        <option name="BACKGROUND" value="273627" />
+        <option name="BACKGROUND" value="242632" />
       </value>
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="IVAR" />
-    <option name="JADE_FILE_PATH">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_LABEL" name="JADE_FILTER_NAME" />
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="JADE_JS_BLOCK" />
-    <option name="JADE_STATEMENTS">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="JAVA_BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="JAVA_BRACES" />
-    <option baseAttributes="TEXT" name="JAVA_BRACKETS" />
-    <option baseAttributes="TEXT" name="JAVA_COMMA" />
-    <option name="JAVA_DOC_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value>
-        <option name="BACKGROUND" value="223f22" />
-      </value>
-    </option>
-    <option name="JAVA_DOC_TAG">
-      <value>
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8f8f2" />
         <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="JAVA_DOT" />
-    <option name="JAVA_INVALID_STRING_ESCAPE">
+    <option name="INTERFACE_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
     <option name="JAVA_KEYWORD">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="JAVA_LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="JAVA_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="JAVA_OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="JAVA_PARENTH" />
-    <option baseAttributes="TEXT" name="JAVA_SEMICOLON" />
-    <option name="JAVA_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="JAVA_VALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="JS.GLOBAL_VARIABLE">
-      <value>
-        <option name="FONT_TYPE" value="2" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="JS.INSTANCE_MEMBER_FUNCTION">
@@ -891,385 +387,388 @@
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="JS.LOCAL_VARIABLE" />
+    <option name="JS.INSTANCE_MEMBER_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="JS.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ffb86c" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="JS.PARAMETER">
       <value>
         <option name="FOREGROUND" value="ffb86c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="JS.REGEXP">
+    <option name="JS.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
-    <option name="LABEL">
+    <option name="JSON.BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="6272a4" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="LESS_INJECTED_CODE" />
-    <option name="LESS_JS_CODE_DELIM">
+    <option name="JSON.KEYWORD">
       <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="LESS_VARIABLE" />
-    <option baseAttributes="TEXT" name="LOCAL_VARIABLE_ATTRIBUTES" />
-    <option name="MACRONAME">
+    <option name="JSON.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="6272a4" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JSON.PROPERTY_KEY">
+      <value>
+        <option name="FOREGROUND" value="f1fa8c" />
+      </value>
+    </option>
+    <option name="JSP_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="MACRO_PARAMETER" />
+    <option name="JSP_DIRECTIVE_NAME">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JSP_SCRIPTING_BACKGROUND">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="KOTLIN_ANNOTATION">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="KOTLIN_ENUM_ENTRY">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+      </value>
+    </option>
+    <option name="KOTLIN_IMPLICIT_EXHAUSTIVE_WHEN">
+      <value />
+    </option>
+    <option name="KOTLIN_INSTANCE_PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+      </value>
+    </option>
+    <option name="KOTLIN_LABEL">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="KOTLIN_MUTABLE_VARIABLE">
+      <value>
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="KOTLIN_PACKAGE_PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="KOTLIN_PROPERTY_WITH_BACKING_FIELD">
+      <value />
+    </option>
+    <option name="KOTLIN_SMART_CAST_RECEIVER">
+      <value />
+    </option>
+    <option name="KOTLIN_SMART_CONSTANT">
+      <value />
+    </option>
+    <option name="KOTLIN_TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="MAKO.SUBSTITUTION">
+      <value />
+    </option>
+    <option name="MARKDOWN_AUTO_LINK">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="EFFECT_COLOR" value="287bde" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MARKDOWN_HEADER_LEVEL_1">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MARKDOWN_LINK_DESTINATION">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MARKDOWN_LINK_LABEL">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="MARKDOWN_LINK_TEXT">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="3a6da0" />
+        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="BACKGROUND" value="3b514d" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="MESSAGE_ARGUMENT">
+    <option name="METHOD_DECLARATION_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option name="NOT_USED_ELEMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="80807f" />
-      </value>
-    </option>
-    <option name="OC.BADCHARACTER">
-      <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="OC.BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.BRACES" />
-    <option baseAttributes="OC.DOT" name="OC.BRACKETS" />
-    <option baseAttributes="OC.DOT" name="OC.COMMA" />
-    <option name="OC.CPP_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="OC.DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="OC.DOT" />
-    <option baseAttributes="OC.LOCAL_VARIABLE" name="OC.EXTERN_VARIABLE" />
-    <option name="OC.FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option name="OC.FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option baseAttributes="OC.LOCAL_VARIABLE" name="OC.GLOBAL_VARIABLE" />
-    <option name="OC.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="OC.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="OC.LOCAL_VARIABLE" />
-    <option name="OC.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.OPERATION_SIGN" />
-    <option name="OC.PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="ffb86c" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.PARENTHS" />
-    <option baseAttributes="IVAR" name="OC.PROPERTY" />
-    <option baseAttributes="OC.KEYWORD" name="OC.SELFSUPERTHIS" />
-    <option baseAttributes="OC.DOT" name="OC.SEMICOLON" />
-    <option name="OC.STRING">
+    <option name="PHP_CONSTANT" baseAttributes="DEFAULT_CONSTANT" />
+    <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
-    <option name="OC.STRUCT_FIELD">
+    <option name="PHP_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
-    <option name="OC_FORMAT_TOKEN">
+    <option name="PHP_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="PARAMETER_ATTRIBUTES" />
+    <option name="PHP_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="PHP_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
     <option name="PHP_PARAMETER">
       <value>
-        <option name="FOREGROUND" value="ffb86c" />
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="PHP_STATIC_FIELD">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="PHP_VAR" />
-    <option name="PROTOCOL_REFERENCE">
+    <option name="PHP_VAR">
       <value>
-        <option name="FOREGROUND" value="50fa7b" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
-    <option name="PUPPET_BAD_CHARACTER">
+    <option name="PROPERTIES.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="PUPPET_BLOCK_COMMENT">
+    <option name="PROPERTIES.KEY">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_BRACES" name="PUPPET_BRACES" />
-    <option baseAttributes="DEFAULT_BRACKETS" name="PUPPET_BRACKETS" />
-    <option baseAttributes="DEFAULT_CLASS_NAME" name="PUPPET_CLASS" />
-    <option baseAttributes="DEFAULT_COMMA" name="PUPPET_COMMA" />
-    <option baseAttributes="DEFAULT_DOT" name="PUPPET_DOT" />
-    <option name="PUPPET_ESCAPE_SEQUENCE">
+    <option name="PROPERTIES.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
       </value>
     </option>
-    <option name="PUPPET_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="PUPPET_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="PUPPET_OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_PARENTHS" name="PUPPET_PARENTH" />
-    <option name="PUPPET_REGEX">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="PUPPET_RESOURCE_REFERENCE" />
-    <option baseAttributes="DEFAULT_SEMICOLON" name="PUPPET_SEMICOLON" />
-    <option name="PUPPET_SQ_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="PUPPET_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_LOCAL_VARIABLE" name="PUPPET_VARIABLE" />
-    <option name="PUPPET_VARIABLE_INTERPOLATION">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_BRACES" name="PY.BRACES" />
-    <option baseAttributes="DEFAULT_BRACKETS" name="PY.BRACKETS" />
     <option name="PY.BUILTIN_NAME">
       <value>
         <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
-    <option name="PY.CLASS_DEFINITION">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="50fa7b" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_COMMA" name="PY.COMMA" />
     <option name="PY.DECORATOR">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="PY.DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_DOT" name="PY.DOT" />
-    <option name="PY.FUNC_DEFINITION">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option name="PY.INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="PY.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="8be9fd" />
+        <option name="FOREGROUND" value="f1fa8c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="PY.LINE_COMMENT">
+    <option name="PY.DOC_COMMENT_TAG">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
+        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FONT_TYPE" value="3" />
+        <option name="EFFECT_COLOR" value="c5ce71" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="PY.NUMBER">
+    <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="PY.PREDEFINED_DEFINITION">
       <value>
-        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
-    <option name="PY.OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_PARENTHS" name="PY.PARENTHS" />
-    <option baseAttributes="TEXT" name="PY.PREDEFINED_DEFINITION" />
     <option name="PY.PREDEFINED_USAGE">
       <value>
         <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
-    <option name="PY.STRING">
+    <option name="PY.STRING.B" baseAttributes="DEFAULT_STRING" />
+    <option name="PY.STRING.U">
       <value>
         <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
-    <option name="PY.VALID_STRING_ESCAPE">
+    <option name="QL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="QL_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+      </value>
+    </option>
+    <option name="REGEXP.BRACES">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
       </value>
     </option>
-    <option name="REST.BOLD">
+    <option name="REGEXP.BRACKETS">
       <value>
+        <option name="FOREGROUND" value="ff79c6" />
+      </value>
+    </option>
+    <option name="REGEXP.CHAR_CLASS">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REST.EXPLICIT">
+    <option name="REGEXP.COMMA">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
       </value>
     </option>
-    <option name="REST.FIELD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="REST.FIXED">
-      <value>
-        <option name="BACKGROUND" value="48485f" />
-      </value>
-    </option>
-    <option name="REST.INLINE">
-      <value>
-        <option name="BACKGROUND" value="273627" />
-      </value>
-    </option>
-    <option name="REST.INTERPRETED">
-      <value>
-        <option name="BACKGROUND" value="4d5d3d" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="REST.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="REST.REF.NAME">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="REST.SECTION.HEADER">
+    <option name="REGEXP.ESC_CHARACTER">
       <value>
         <option name="FOREGROUND" value="bd93f9" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="RHTML_COMMENT_ID">
+    <option name="REGEXP.INVALID_STRING_ESCAPE">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option baseAttributes="XML_TAG" name="RHTML_EXPRESSION_END_ID" />
-    <option baseAttributes="XML_TAG" name="RHTML_EXPRESSION_START_ID" />
-    <option baseAttributes="XML_TAG" name="RHTML_OMIT_NEW_LINE_ID" />
-    <option baseAttributes="XML_TAG" name="RHTML_SCRIPTING_BACKGROUND_ID" />
-    <option baseAttributes="XML_TAG" name="RHTML_SCRIPTLET_END_ID" />
-    <option baseAttributes="XML_TAG" name="RHTML_SCRIPTLET_START_ID" />
+    <option name="REGEXP.META">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="REGEXP.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+      </value>
+    </option>
+    <option name="REGEXP.QUOTE_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="REGEXP.REDUNDANT_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="RUBY_BAD_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_BRACKETS" name="RUBY_BRACKETS" />
-    <option baseAttributes="DEFAULT_SEMICOLON" name="RUBY_COLON" />
-    <option baseAttributes="DEFAULT_COMMA" name="RUBY_COMMA" />
     <option name="RUBY_COMMENT">
       <value>
         <option name="FOREGROUND" value="6272a4" />
       </value>
     </option>
-    <option baseAttributes="RUBY_IDENTIFIER" name="RUBY_CONSTANT" />
-    <option baseAttributes="RUBY_IDENTIFIER" name="RUBY_CONSTANT_DECLARATION" />
-    <option baseAttributes="RUBY_IDENTIFIER" name="RUBY_CVAR" />
-    <option baseAttributes="DEFAULT_DOT" name="RUBY_DOT" />
+    <option name="RUBY_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="50fa7b" />
+      </value>
+    </option>
+    <option name="RUBY_CVAR">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
     <option name="RUBY_ESCAPE_SEQUENCE">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
       </value>
     </option>
-    <option name="RUBY_EXPR_IN_STRING">
+    <option name="RUBY_GVAR">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
-    <option baseAttributes="RUBY_IDENTIFIER" name="RUBY_GVAR" />
     <option name="RUBY_HASH_ASSOC">
       <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FOREGROUND" value="6272a4" />
+        <option name="BACKGROUND" value="282a36" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="RUBY_HEREDOC_ID">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="RUBY_IDENTIFIER" />
     <option name="RUBY_INTERPOLATED_STRING">
       <value>
         <option name="FOREGROUND" value="f1fa8c" />
@@ -1277,8 +776,9 @@
     </option>
     <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
       <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="EFFECT_COLOR" value="ff5555" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="RUBY_IVAR">
@@ -1286,28 +786,25 @@
         <option name="FOREGROUND" value="ffb86c" />
       </value>
     </option>
-    <option name="RUBY_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
     <option name="RUBY_LINE_CONTINUATION">
+      <value />
+    </option>
+    <option name="RUBY_LOCAL_VAR_ID">
       <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
-    <option baseAttributes="RUBY_IDENTIFIER" name="RUBY_LOCAL_VAR_ID" />
     <option name="RUBY_METHOD_NAME">
       <value>
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="RUBY_NTH_REF" />
-    <option name="RUBY_NUMBER">
+    <option name="RUBY_NTH_REF">
       <value>
-        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
+    <option name="RUBY_NUMBER" baseAttributes="DEFAULT_NUMBER" />
     <option name="RUBY_OPERATION_SIGN">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
@@ -1315,7 +812,8 @@
     </option>
     <option name="RUBY_PARAMDEF_CALL">
       <value>
-        <option name="FOREGROUND" value="8be9fd" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="RUBY_PARAMETER_ID">
@@ -1326,18 +824,12 @@
     </option>
     <option name="RUBY_REGEXP">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="BACKGROUND" value="242632" />
       </value>
     </option>
-    <option baseAttributes="DEFAULT_SEMICOLON" name="RUBY_SEMICOLON" />
     <option name="RUBY_SPECIFIC_CALL">
       <value>
         <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="RUBY_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
     <option name="RUBY_SYMBOL">
@@ -1345,248 +837,121 @@
         <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
-    <option name="RUBY_WORDS">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="SASS_DEFAULT">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SASS_EXTEND">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SASS_FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="6be5fd" />
-      </value>
-    </option>
-    <option name="SASS_IDENTIFIER">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option name="SASS_IMPORTANT">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SASS_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option name="SASS_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="bd93f9" />
-      </value>
-    </option>
-    <option name="SASS_PROPERTY_NAME">
-      <value>
-        <option name="FOREGROUND" value="66d9ef" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_PROPERTY_VALUE">
-      <value>
-        <option name="FOREGROUND" value="6be5fd" />
-      </value>
-    </option>
-    <option name="SASS_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="SASS_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SASS_URL">
-      <value>
-        <option name="FOREGROUND" value="6be5fd" />
-      </value>
-    </option>
     <option name="SASS_VARIABLE">
       <value>
-        <option name="FOREGROUND" value="ffb86c" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4f4f82" />
+        <option name="BACKGROUND" value="666b87" />
       </value>
     </option>
-    <option name="SLIM_BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="F8F8F0" />
-        <option name="BACKGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_CALL" />
-    <option name="SLIM_CLASS">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SLIM_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="SLIM_DOCTYPE_KWD">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SLIM_FILTER">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_FILTER_CONTENT" />
-    <option name="SLIM_ID">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SLIM_INTERPOLATION">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_PARENTHS" name="SLIM_PARENTHS" />
-    <option baseAttributes="HAML_TEXT" name="SLIM_RUBY_CODE" />
-    <option baseAttributes="TEXT" name="SLIM_STATIC_CONTENT" />
-    <option name="SLIM_STRING_INTERPOLATED">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="SLIM_TAG">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
-      </value>
-    </option>
-    <option name="SLIM_TAG_ATTR_KEY">
-      <value>
-        <option name="FOREGROUND" value="50fa7b" />
-      </value>
-    </option>
-    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_TAG_START" />
     <option name="SPY-JS.EXCEPTION">
       <value>
-        <option name="BACKGROUND" value="713f3f" />
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="f8f8f2" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
       <value>
-        <option name="BACKGROUND" value="2e2e20" />
         <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="f8f8f2" />
       </value>
     </option>
-    <option name="SPY-JS.PATH_LEVEL_ONE">
-      <value>
-        <option name="BACKGROUND" value="264226" />
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="f8f8f2" />
-      </value>
-    </option>
-    <option name="SPY-JS.PATH_LEVEL_TWO">
-      <value>
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="f8f8f2" />
-      </value>
-    </option>
-    <option name="SPY-JS.PROGRAM_SCOPE">
-      <value>
-        <option name="BACKGROUND" value="2b2b2b" />
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="f8f8f2" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="fda5ff" />
-        <option name="FONT_TYPE" value="3" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
         <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="TAG_ATTR_KEY">
+    <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="50fa7b" />
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="Scala Immutable Collection">
+      <value>
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="Scala Mutable Collection">
+      <value>
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="Scala Predefined types">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="Scala Type Alias" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES" />
+    <option name="Scala Type parameter" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES" />
+    <option name="Standart Java Collection">
+      <value>
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES" />
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="f8f8f2" />
         <option name="BACKGROUND" value="282a36" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+        <option name="BACKGROUND" value="2c763b" />
+        <option name="EFFECT_COLOR" value="3c704b" />
+        <option name="ERROR_STRIPE_COLOR" value="61936f" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-        <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
+        <option name="FOREGROUND" value="79cbdc" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="ERROR_STRIPE_COLOR" value="977ab" />
       </value>
     </option>
-    <option name="TYPEDEF">
+    <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8be9fd" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="UNMATCHED_BRACE_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="583535" />
+        <option name="FOREGROUND" value="cd4848" />
+      </value>
+    </option>
+    <option name="Valid string escape">
+      <value>
+        <option name="FOREGROUND" value="f1fa8c" />
       </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="4a3f10" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="f8f8f2" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+        <option name="EFFECT_COLOR" value="f1fa8c" />
+        <option name="ERROR_STRIPE_COLOR" value="be9117" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+        <option name="BACKGROUND" value="6d7641" />
+        <option name="ERROR_STRIPE_COLOR" value="b56277" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="623062" />
+        <option name="BACKGROUND" value="933232" />
+      </value>
+    </option>
+    <option name="WRONG_REFERENCES_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ff5555" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_NAME">
@@ -1594,71 +959,43 @@
         <option name="FOREGROUND" value="50fa7b" />
       </value>
     </option>
-    <option name="XML_ATTRIBUTE_VALUE">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
     <option name="XML_ENTITY_REFERENCE">
       <value>
         <option name="FOREGROUND" value="bd93f9" />
       </value>
     </option>
-    <option name="XML_PROLOGUE">
+    <option name="XML_NS_PREFIX">
       <value>
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
-    <option baseAttributes="TEXT" name="XML_TAG" />
-    <option name="XML_TAG_DATA">
+    <option name="XML_TAG">
       <value>
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="XML_TAG_NAME">
       <value>
-        <option name="FOREGROUND" value="e3e3ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="YAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="6272a4" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_DSTRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FOREGROUND" value="ff79c6" />
       </value>
     </option>
     <option name="YAML_SCALAR_KEY">
       <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
     <option name="YAML_SCALAR_LIST">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_STRING">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_VALUE">
-      <value>
-        <option name="FOREGROUND" value="f1fa8c" />
-      </value>
-    </option>
-    <option name="YAML_SIGN">
-      <value>
-        <option name="FOREGROUND" value="ff79c6" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="282a36" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="YAML_TEXT">
       <value>
-        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="282a36" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
   </attributes>


### PR DESCRIPTION
Includes a modified version of the original PR #148, trying to match the Atom highlight.

Included languages are:
 - Java
 - Groovy
 - Kotlin
 - Scala
 - Javascript
 - Typescript
 - CSS
 - SASS
 - Python
 - Ruby
 - PHP
 - XML & HTML
 - Bash
 - Go

Some templating languages are also matched by the default highlight such as Markdown, Mako, Django templates

Screenshots:

 Java
![java](https://cloud.githubusercontent.com/assets/5256711/15116230/d6b76d10-15d8-11e6-8c01-f4b3a61491c3.png)

JS
![js](https://cloud.githubusercontent.com/assets/5256711/15116231/d6ba81e4-15d8-11e6-8e4b-5056d259a2a4.png)

PHP
![php](https://cloud.githubusercontent.com/assets/5256711/15116233/d6c057d6-15d8-11e6-8487-c9eee1023b35.png)

Py
![py](https://cloud.githubusercontent.com/assets/5256711/15116232/d6bc9dc6-15d8-11e6-87f5-a2028ccae449.png)

Ruby
![rb](https://cloud.githubusercontent.com/assets/5256711/15116234/d6c2f1bc-15d8-11e6-91b0-eb3c4ab0d7d4.png)

SCSS
![scss](https://cloud.githubusercontent.com/assets/5256711/15116236/d6c41ee8-15d8-11e6-8e79-912cc2728ec6.png)

XML
![xml](https://cloud.githubusercontent.com/assets/5256711/15116237/d6d752ce-15d8-11e6-95c4-fc9a622c5230.png)

Go
![go](https://cloud.githubusercontent.com/assets/5256711/15116334/35732ac4-15d9-11e6-85a4-62fa09c31586.png)
