### PR TITLE
refine instructions for Installing using Atom

### DIFF
--- a/src/content/atom/index.html
+++ b/src/content/atom/index.html
@@ -18,7 +18,6 @@ icon_height: 204
 		<li>Then select the <code>Install</code> tab</li>
 		<li>Click the <code>Themes</code> button to the right of the search box</li>
 		<li>Enter <code>dracula-theme</code> in the search box</li>
-
 	</ol>
 
 	<h4>Install using Git</h4>

--- a/src/content/atom/index.html
+++ b/src/content/atom/index.html
@@ -15,8 +15,10 @@ icon_height: 204
 	<h4>Install using Atom</h4>
 	<ol>
 		<li>Go to <code>Atom -> Preferences...</code></li>
-		<li>Then select the <code>Themes</code> tab</li>
-		<li>Enter <code>Dracula</code> in the search box</li>
+		<li>Then select the <code>Install</code> tab</li>
+		<li>Click the <code>Themes</code> button to the right of the search box </li>
+		<li>Enter <code>Dracula-theme</code> in the search box</li>
+
 	</ol>
 
 	<h4>Install using Git</h4>

--- a/src/content/atom/index.html
+++ b/src/content/atom/index.html
@@ -16,8 +16,8 @@ icon_height: 204
 	<ol>
 		<li>Go to <code>Atom -> Preferences...</code></li>
 		<li>Then select the <code>Install</code> tab</li>
-		<li>Click the <code>Themes</code> button to the right of the search box </li>
-		<li>Enter <code>Dracula-theme</code> in the search box</li>
+		<li>Click the <code>Themes</code> button to the right of the search box</li>
+		<li>Enter <code>dracula-theme</code> in the search box</li>
 
 	</ol>
 


### PR DESCRIPTION
In the current version of Atom (1.7.3), themes are installed on the *Install* tab rather than the *Themes* tab. I also made the search term more specific so that this theme is the first match. See also #166. Look ok  @JimmyMultani ?