### PR TITLE
Update Pygments theme support

### DIFF
--- a/pygments/dracula.css
+++ b/pygments/dracula.css
@@ -8,76 +8,84 @@
  * http://zenorocha.mit-license.org
  *
  * @author Rob G <wowmotty@gmail.com>
+ * @author Chris Bracco <chris@cbracco.me>
  * @author Zeno Rocha <hi@zenorocha.com>
  */
 
-.highlight .hll { background-color: #ffffcc; }
-.highlight { background: #282a36; color: #f8f8f2; background-color: #282a36; }
-.highlight .c { color: #6272a4; background-color: #282a36; } /* Comment */
-.highlight .err { color: #f8f8f2; background-color: #282a36; } /* Error */
-.highlight .g { color: #f8f8f2; background-color: #282a36; } /* Generic */
-.highlight .k { color: #ff79c6; background-color: #282a36; } /* Keyword */
-.highlight .l { color: #f8f8f2; background-color: #282a36; } /* Literal */
-.highlight .n { color: #f8f8f2; background-color: #282a36; } /* Name */
-.highlight .o { color: #f8f8f2; background-color: #282a36; } /* Operator */
-.highlight .x { color: #f8f8f2; background-color: #282a36; } /* Other */
-.highlight .p { color: #f8f8f2; background-color: #282a36; } /* Punctuation */
-.highlight .cm { color: #6272a4; background-color: #282a36; } /* Comment.Multiline */
-.highlight .cp { color: #ff79c6; background-color: #282a36; } /* Comment.Preproc */
-.highlight .c1 { color: #6272a4; background-color: #282a36; } /* Comment.Single */
-.highlight .cs { color: #6272a4; background-color: #282a36; } /* Comment.Special */
-.highlight .gd { color: #8b080b; background-color: #282a36; } /* Generic.Deleted */
-.highlight .ge { color: #f8f8f2; text-decoration: underline; background-color: #282a36; } /* Generic.Emph */
-.highlight .gr { color: #f8f8f2; background-color: #282a36; } /* Generic.Error */
-.highlight .gh { color: #f8f8f2; font-weight: bold; background-color: #282a36; } /* Generic.Heading */
-.highlight .gi { color: #f8f8f2; font-weight: bold; background-color: #468410; } /* Generic.Inserted */
-.highlight .go { color: #3b3a32; background-color: #32343f; } /* Generic.Output */
-.highlight .gp { color: #f8f8f2; background-color: #282a36; } /* Generic.Prompt */
-.highlight .gs { color: #f8f8f2; background-color: #282a36; } /* Generic.Strong */
-.highlight .gu { color: #f8f8f2; font-weight: bold; background-color: #282a36; } /* Generic.Subheading */
-.highlight .gt { color: #f8f8f0; background-color: #ff79c6; } /* Generic.Traceback */
-.highlight .kc { color: #ff79c6; background-color: #282a36; } /* Keyword.Constant */
-.highlight .kd { color: #ff79c6; background-color: #282a36; } /* Keyword.Declaration */
-.highlight .kn { color: #ff79c6; background-color: #282a36; } /* Keyword.Namespace */
-.highlight .kp { color: #ff79c6; background-color: #282a36; } /* Keyword.Pseudo */
-.highlight .kr { color: #ff79c6; background-color: #282a36; } /* Keyword.Reserved */
-.highlight .kt { color: #f8f8f2; background-color: #282a36; } /* Keyword.Type */
-.highlight .ld { color: #f8f8f2; background-color: #282a36; } /* Literal.Date */
-.highlight .m { color: #bd93f9; background-color: #282a36; } /* Literal.Number */
-.highlight .s { color: #f1fa8c; background-color: #282a36; } /* Literal.String */
-.highlight .na { color: #50fa7b; background-color: #282a36; } /* Name.Attribute */
-.highlight .nb { color: #f8f8f2; background-color: #282a36; } /* Name.Builtin */
-.highlight .nc { color: #f8f8f2; background-color: #282a36; } /* Name.Class */
-.highlight .no { color: #f8f8f2; background-color: #282a36; } /* Name.Constant */
-.highlight .nd { color: #f8f8f2; background-color: #282a36; } /* Name.Decorator */
-.highlight .ni { color: #f8f8f2; background-color: #282a36; } /* Name.Entity */
-.highlight .ne { color: #f8f8f2; background-color: #282a36; } /* Name.Exception */
-.highlight .nf { color: #50fa7b; background-color: #282a36; } /* Name.Function */
-.highlight .nl { color: #f1fa8c; background-color: #282a36; } /* Name.Label */
-.highlight .nn { color: #f8f8f2; background-color: #282a36; } /* Name.Namespace */
-.highlight .nx { color: #f8f8f2; background-color: #282a36; } /* Name.Other */
-.highlight .py { color: #f8f8f2; background-color: #282a36; } /* Name.Property */
-.highlight .nt { color: #ff79c6; background-color: #282a36; } /* Name.Tag */
-.highlight .nv { color: #8be9fd; font-style: italic; background-color: #282a36; } /* Name.Variable */
-.highlight .ow { color: #ff79c6; background-color: #282a36; } /* Operator.Word */
-.highlight .w { color: #f8f8f2; background-color: #282a36; } /* Text.Whitespace */
-.highlight .mf { color: #bd93f9; background-color: #282a36; } /* Literal.Number.Float */
-.highlight .mh { color: #bd93f9; background-color: #282a36; } /* Literal.Number.Hex */
-.highlight .mi { color: #bd93f9; background-color: #282a36; } /* Literal.Number.Integer */
-.highlight .mo { color: #bd93f9; background-color: #282a36; } /* Literal.Number.Oct */
-.highlight .sb { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Backtick */
-.highlight .sc { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Char */
-.highlight .sd { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Doc */
-.highlight .s2 { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Double */
-.highlight .se { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Escape */
-.highlight .sh { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Heredoc */
-.highlight .si { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Interpol */
-.highlight .sx { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Other */
-.highlight .sr { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Regex */
-.highlight .s1 { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Single */
-.highlight .ss { color: #f1fa8c; background-color: #282a36; } /* Literal.String.Symbol */
-.highlight .bp { color: #f8f8f2; background-color: #282a36; } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #8be9fd; font-style: italic; background-color: #282a36; } /* Name.Variable.Class */
-.highlight .vg { color: #8be9fd; font-style: italic; background-color: #282a36; } /* Name.Variable.Global */
-.highlight .vi { color: #8be9fd; font-style: italic; background-color: #282a36; } /* Name.Variable.Instance */
-.highlight .il { color: #bd93f9; background-color: #282a36; } /* Literal.Number.Integer.Long */
+ .highlight .hll { background-color: #ffffcc }
+ .highlight  { background: #282a36; color: #f8f8f2 }
+ .highlight .c { color: #6272a4 } /* Comment */
+ .highlight .err { color: #f8f8f2 } /* Error */
+ .highlight .g { color: #f8f8f2 } /* Generic */
+ .highlight .k { color: #ff79c6 } /* Keyword */
+ .highlight .l { color: #f8f8f2 } /* Literal */
+ .highlight .n { color: #f8f8f2 } /* Name */
+ .highlight .o { color: #ff79c6 } /* Operator */
+ .highlight .x { color: #f8f8f2 } /* Other */
+ .highlight .p { color: #f8f8f2 } /* Punctuation */
+ .highlight .ch { color: #6272a4 } /* Comment.Hashbang */
+ .highlight .cm { color: #6272a4 } /* Comment.Multiline */
+ .highlight .cp { color: #ff79c6 } /* Comment.Preproc */
+ .highlight .cpf { color: #6272a4 } /* Comment.PreprocFile */
+ .highlight .c1 { color: #6272a4 } /* Comment.Single */
+ .highlight .cs { color: #6272a4 } /* Comment.Special */
+ .highlight .gd { color: #8b080b } /* Generic.Deleted */
+ .highlight .ge { color: #f8f8f2; text-decoration: underline } /* Generic.Emph */
+ .highlight .gr { color: #f8f8f2 } /* Generic.Error */
+ .highlight .gh { color: #f8f8f2; font-weight: bold } /* Generic.Heading */
+ .highlight .gi { color: #f8f8f2; font-weight: bold } /* Generic.Inserted */
+ .highlight .go { color: #525563 } /* Generic.Output */
+ .highlight .gp { color: #f8f8f2 } /* Generic.Prompt */
+ .highlight .gs { color: #f8f8f2 } /* Generic.Strong */
+ .highlight .gu { color: #f8f8f2; font-weight: bold } /* Generic.Subheading */
+ .highlight .gt { color: #f8f8f2 } /* Generic.Traceback */
+ .highlight .kc { color: #ff79c6 } /* Keyword.Constant */
+ .highlight .kd { color: #8be9fd; font-style: italic } /* Keyword.Declaration */
+ .highlight .kn { color: #ff79c6 } /* Keyword.Namespace */
+ .highlight .kp { color: #ff79c6 } /* Keyword.Pseudo */
+ .highlight .kr { color: #ff79c6 } /* Keyword.Reserved */
+ .highlight .kt { color: #8be9fd } /* Keyword.Type */
+ .highlight .ld { color: #f8f8f2 } /* Literal.Date */
+ .highlight .m { color: #bd93f9 } /* Literal.Number */
+ .highlight .s { color: #f1fa8c } /* Literal.String */
+ .highlight .na { color: #50fa7b } /* Name.Attribute */
+ .highlight .nb { color: #8be9fd; font-style: italic } /* Name.Builtin */
+ .highlight .nc { color: #50fa7b } /* Name.Class */
+ .highlight .no { color: #f8f8f2 } /* Name.Constant */
+ .highlight .nd { color: #f8f8f2 } /* Name.Decorator */
+ .highlight .ni { color: #f8f8f2 } /* Name.Entity */
+ .highlight .ne { color: #f8f8f2 } /* Name.Exception */
+ .highlight .nf { color: #50fa7b } /* Name.Function */
+ .highlight .nl { color: #8be9fd; font-style: italic } /* Name.Label */
+ .highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+ .highlight .nx { color: #f8f8f2 } /* Name.Other */
+ .highlight .py { color: #f8f8f2 } /* Name.Property */
+ .highlight .nt { color: #ff79c6 } /* Name.Tag */
+ .highlight .nv { color: #8be9fd; font-style: italic } /* Name.Variable */
+ .highlight .ow { color: #ff79c6 } /* Operator.Word */
+ .highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+ .highlight .mb { color: #bd93f9 } /* Literal.Number.Bin */
+ .highlight .mf { color: #bd93f9 } /* Literal.Number.Float */
+ .highlight .mh { color: #bd93f9 } /* Literal.Number.Hex */
+ .highlight .mi { color: #bd93f9 } /* Literal.Number.Integer */
+ .highlight .mo { color: #bd93f9 } /* Literal.Number.Oct */
+ .highlight .sa { color: #f1fa8c } /* Literal.String.Affix */
+ .highlight .sb { color: #f1fa8c } /* Literal.String.Backtick */
+ .highlight .sc { color: #f1fa8c } /* Literal.String.Char */
+ .highlight .dl { color: #f1fa8c } /* Literal.String.Delimiter */
+ .highlight .sd { color: #f1fa8c } /* Literal.String.Doc */
+ .highlight .s2 { color: #f1fa8c } /* Literal.String.Double */
+ .highlight .se { color: #f1fa8c } /* Literal.String.Escape */
+ .highlight .sh { color: #f1fa8c } /* Literal.String.Heredoc */
+ .highlight .si { color: #f1fa8c } /* Literal.String.Interpol */
+ .highlight .sx { color: #f1fa8c } /* Literal.String.Other */
+ .highlight .sr { color: #f1fa8c } /* Literal.String.Regex */
+ .highlight .s1 { color: #f1fa8c } /* Literal.String.Single */
+ .highlight .ss { color: #f1fa8c } /* Literal.String.Symbol */
+ .highlight .bp { color: #f8f8f2; font-style: italic } /* Name.Builtin.Pseudo */
+ .highlight .fm { color: #50fa7b } /* Name.Function.Magic */
+ .highlight .vc { color: #8be9fd; font-style: italic } /* Name.Variable.Class */
+ .highlight .vg { color: #8be9fd; font-style: italic } /* Name.Variable.Global */
+ .highlight .vi { color: #8be9fd; font-style: italic } /* Name.Variable.Instance */
+ .highlight .vm { color: #8be9fd; font-style: italic } /* Name.Variable.Magic */
+ .highlight .il { color: #bd93f9 } /* Literal.Number.Integer.Long */

--- a/pygments/dracula.py
+++ b/pygments/dracula.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+    Dracula Theme v1.2.5
+
+    https://github.com/zenorocha/dracula-theme
+
+    Copyright 2016, All rights reserved
+
+    Code licensed under the MIT license
+    http://zenorocha.mit-license.org
+
+    :author Rob G <wowmotty@gmail.com>
+    :author Chris Bracco <chris@cbracco.me>
+    :author Zeno Rocha <hi@zenorocha.com>
+"""
+
+from pygments.style import Style
+from pygments.token import Keyword, Name, Comment, String, Error, \
+    Literal, Number, Operator, Other, Punctuation, Text, Generic, \
+    Whitespace
+
+class DraculaStyle(Style):
+
+    background_color = "#282a36"
+    default_style = ""
+
+    styles = {
+        Comment: "#6272a4",
+        Comment.Hashbang: "#6272a4",
+        Comment.Multiline: "#6272a4",
+        Comment.Preproc: "#ff79c6",
+        Comment.Single: "#6272a4",
+        Comment.Special: "#6272a4",
+
+        Generic: "#f8f8f2",
+        Generic.Deleted: "#8b080b",
+        Generic.Emph: "#f8f8f2 underline",
+        Generic.Error: "#f8f8f2",
+        Generic.Heading: "#f8f8f2 bold",
+        Generic.Inserted: "#f8f8f2 bold",
+        Generic.Output: "#525563",
+        Generic.Prompt: "#f8f8f2",
+        Generic.Strong: "#f8f8f2",
+        Generic.Subheading: "#f8f8f2 bold",
+        Generic.Traceback: "#f8f8f2",
+
+        Error: "#f8f8f2",
+
+        Keyword: "#ff79c6",
+        Keyword.Constant: "#ff79c6",
+        Keyword.Declaration: "#8be9fd italic",
+        Keyword.Namespace: "#ff79c6",
+        Keyword.Pseudo: "#ff79c6",
+        Keyword.Reserved: "#ff79c6",
+        Keyword.Type: "#8be9fd",
+
+        Literal: "#f8f8f2",
+        Literal.Date: "#f8f8f2",
+
+        Name: "#f8f8f2",
+        Name.Attribute: "#50fa7b",
+        Name.Builtin: "#8be9fd italic",
+        Name.Builtin.Pseudo: "#f8f8f2",
+        Name.Class: "#50fa7b",
+        Name.Constant: "#f8f8f2",
+        Name.Decorator: "#f8f8f2",
+        Name.Entity: "#f8f8f2",
+        Name.Exception: "#f8f8f2",
+        Name.Function: "#50fa7b",
+        Name.Label: "#8be9fd italic",
+        Name.Namespace: "#f8f8f2",
+        Name.Other: "#f8f8f2",
+        Name.Tag: "#ff79c6",
+        Name.Variable: "#8be9fd italic",
+        Name.Variable.Class: "#8be9fd italic",
+        Name.Variable.Global: "#8be9fd italic",
+        Name.Variable.Instance: "#8be9fd italic",
+
+        Number: "#bd93f9",
+        Number.Bin: "#bd93f9",
+        Number.Float: "#bd93f9",
+        Number.Hex: "#bd93f9",
+        Number.Integer: "#bd93f9",
+        Number.Integer.Long: "#bd93f9",
+        Number.Oct: "#bd93f9",
+
+        Operator: "#ff79c6",
+        Operator.Word: "#ff79c6",
+
+        Other: "#f8f8f2",
+
+        Punctuation: "#f8f8f2",
+
+        String: "#f1fa8c",
+        String.Backtick: "#f1fa8c",
+        String.Char: "#f1fa8c",
+        String.Doc: "#f1fa8c",
+        String.Double: "#f1fa8c",
+        String.Escape: "#f1fa8c",
+        String.Heredoc: "#f1fa8c",
+        String.Interpol: "#f1fa8c",
+        String.Other: "#f1fa8c",
+        String.Regex: "#f1fa8c",
+        String.Single: "#f1fa8c",
+        String.Symbol: "#f1fa8c",
+
+        Text: "#f8f8f2",
+
+        Whitespace: "#f8f8f2"
+    }


### PR DESCRIPTION
Hi @zenorocha and @Mottie!

This pull request addresses #61, providing some updates to the Pygments CSS theme that @Mottie had generated. It also includes the `dracula.py` file so that users can generate their own CSS file if they wish.

Definitely welcoming any improvements to the `dracula.py` file. 🐴 

**To-Do**

- [x] Add the `dracula.py` file.
- [x] Update the `dracula.css` file.
- [ ] Design a Pygments icon and add a page to the website.

I tested the CSS using Rouge (which supports Pygments themes), and it works pretty well (see screenshot below)! There are some differences that are likely unavoidable due to how Pygments interprets syntax, but overall I think its pretty decent. 

![syntax-highlighting-test](https://cloud.githubusercontent.com/assets/1480677/15344045/e6eab9fa-1c70-11e6-8a4f-56c545772db9.jpg)
