### PR TITLE
Fixed the phpdoc tag color to match Atom.

### DIFF
--- a/jetbrains/Dracula.icls
+++ b/jetbrains/Dracula.icls
@@ -189,9 +189,9 @@
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
       <value>
-        <option name="FOREGROUND" value="6272a4" />
+        <option name="FOREGROUND" value="ff79c6" />
         <option name="FONT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="6272a4" />
+        <option name="EFFECT_COLOR" value="ff79c6" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>


### PR DESCRIPTION
In Atom the tag (`@param` for example) is pink, but in Storm it is currently the same as the comment color (purple). This fixes it to match Atom.