### PR TITLE
`highlight clear` added in PR #168 causes all theme settings to be cleared.

### DIFF
--- a/vim/colors/dracula.vim
+++ b/vim/colors/dracula.vim
@@ -134,5 +134,4 @@ hi TabLineSel   guifg=WHITE guibg=#1e1f29 gui=none
 "      export $TERM
 
 execute "set background=dark"
-highlight clear
 "-------------------


### PR DESCRIPTION
This commit simply removes `highlight clear`. The
Cygwin issue addressed by PR #168 may be re-introduced. I don't
have a windows environment to test.