### PR TITLE
Fix image links for color palette on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ I hope so, but I need your help to accomplish that. Since you're using code edit
 
 ## Color Palette
 
-Palette      | Hex       | RGB           | HSL             | ![Color Picker Boxes](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/eyedropper.png)
+Palette      | Hex       | RGB           | HSL             | ![Color Picker Boxes](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/eyedropper.png)
 ---          | ---       | ---           | ---             | ---
-Background   | `#282a36` | `40 42 54`    | `231° 15% 18%`  | ![Background Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/background.png)
-Current Line | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Current Line Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/current_line.png)
-Selection    | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Selection Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/selection.png)
-Foreground   | `#f8f8f2` | `248 248 242` | `60° 30% 96%`   | ![Foreground Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/foreground.png)
-Comment      | `#6272a4` | `98 114 164`  | `225° 27% 51%`  | ![Comment Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/comment.png)
-Cyan         | `#8be9fd` | `139 233 253` | `191° 97% 77%`  | ![Cyan Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/cyan.png)
-Green        | `#50fa7b` | `80 250 123`  | `135° 94% 65%`  | ![Green Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/green.png)
-Orange       | `#ffb86c` | `255 184 108` | `31° 100% 71%`  | ![Orange Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/orange.png)
-Pink         | `#ff79c6` | `255 121 198` | `326° 100% 74%` | ![Pink Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/pink.png)
-Purple       | `#bd93f9` | `189 147 249` | `265° 89% 78%`  | ![Purple Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/purple.png)
-Red          | `#ff5555` | `255 85 85`   | `0° 100% 67%`   | ![Red Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/red.png)
-Yellow       | `#f1fa8c` | `241 250 140` | `65° 92% 76%`   | ![Yellow Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/site/src/assets/img/color-boxes/yellow.png)
+Background   | `#282a36` | `40 42 54`    | `231° 15% 18%`  | ![Background Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/background.png)
+Current Line | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Current Line Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/current_line.png)
+Selection    | `#44475a` | `68 71 90`    | `232° 14% 31%`  | ![Selection Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/selection.png)
+Foreground   | `#f8f8f2` | `248 248 242` | `60° 30% 96%`   | ![Foreground Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/foreground.png)
+Comment      | `#6272a4` | `98 114 164`  | `225° 27% 51%`  | ![Comment Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/comment.png)
+Cyan         | `#8be9fd` | `139 233 253` | `191° 97% 77%`  | ![Cyan Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/cyan.png)
+Green        | `#50fa7b` | `80 250 123`  | `135° 94% 65%`  | ![Green Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/green.png)
+Orange       | `#ffb86c` | `255 184 108` | `31° 100% 71%`  | ![Orange Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/orange.png)
+Pink         | `#ff79c6` | `255 121 198` | `326° 100% 74%` | ![Pink Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/pink.png)
+Purple       | `#bd93f9` | `189 147 249` | `265° 89% 78%`  | ![Purple Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/purple.png)
+Red          | `#ff5555` | `255 85 85`   | `0° 100% 67%`   | ![Red Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/red.png)
+Yellow       | `#f1fa8c` | `241 250 140` | `65° 92% 76%`   | ![Yellow Color](https://raw.githubusercontent.com/zenorocha/dracula-theme/gh-pages/assets/img/color-boxes/yellow.png)
 
 ## Team
 


### PR DESCRIPTION
Refer the following screenshot:

![screenshot 2016-05-20 00 59 07](https://cloud.githubusercontent.com/assets/853977/15400324/1300aa34-1e26-11e6-8b75-8b29b611259c.png)
