### PR TITLE
Updating vim colors so Vim and NeoVim

### DIFF
--- a/vim/colors/dracula.vim
+++ b/vim/colors/dracula.vim
@@ -57,12 +57,12 @@ hi Function ctermfg=84 ctermbg=NONE cterm=NONE guifg=#50fa7b guibg=NONE gui=NONE
 hi Identifier ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 hi Keyword ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Label ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE
-hi NonText guifg=#f8f8f2 guibg=#1e1f29 gui=NONE
+hi NonText ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=#1e1f29 gui=NONE
 hi Number ctermfg=141 ctermbg=NONE cterm=NONE guifg=#bd93f9 guibg=NONE gui=NONE
 hi Operator ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi PreProc ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi Special ctermfg=231 ctermbg=NONE cterm=NONE guifg=#f8f8f2 guibg=NONE gui=NONE
-hi SpecialKey ctermfg=59 ctermbg=236 cterm=NONE guifg=#3b3a32 guibg=#3d3f49 gui=NONE
+hi SpecialKey ctermfg=231 ctermbg=235 cterm=NONE guifg=#525563 guibg=#1e1f29 gui=NONE
 hi Statement ctermfg=212 ctermbg=NONE cterm=NONE guifg=#ff79c6 guibg=NONE gui=NONE
 hi StorageClass ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=italic
 hi String ctermfg=228 ctermbg=NONE cterm=NONE guifg=#f1fa8c guibg=NONE gui=NONE


### PR DESCRIPTION
Updating vim colors so Vim and NeoVim so Specialkeys and Nontext gets renfered the same way on vim, NeoVim and MacVim.


Before: ![before](https://cloud.githubusercontent.com/assets/6126301/15450609/8bf0a056-1f76-11e6-877c-9a79bf8a9072.png)

After: ![after](https://cloud.githubusercontent.com/assets/6126301/15450615/bcd84304-1f76-11e6-94ca-e10d7d9f3440.png)
